### PR TITLE
Adds CSS low contrast media query

### DIFF
--- a/app/assets/css/base.scss
+++ b/app/assets/css/base.scss
@@ -146,7 +146,21 @@ section {
     @media (prefers-contrast: more) {
         .section-header {
             h2 {
-                // -webkit-text-stroke: 2px black;
+                color: black;
+                -webkit-text-stroke: 0;
+            }
+
+            &.-yellow {
+                h2 {
+                    color: black;
+                    -webkit-text-stroke: 0;
+                }
+            }
+
+            &.-white {
+                h2 {
+                    color: white;
+                }
             }
         }
     }

--- a/app/components/banner.vue
+++ b/app/components/banner.vue
@@ -88,6 +88,14 @@
       margin-top: -100px;
     }
   }
+
+  @media (prefers-contrast: more) {
+    .copy {
+      h1 {
+        color: black;
+      }
+    }
+  }
 }
 
 </style>

--- a/app/components/learning-item.vue
+++ b/app/components/learning-item.vue
@@ -72,6 +72,15 @@ const classObject = computed(() => {
   &.-index-3 { background-color: var(--grey); transform: rotate(-6.06deg); }
   &.-index-4 { background-color: var(--purple); transform: rotate(-3.16deg); }
   &.-index-5 { background-color: var(--brown); transform: rotate(3.61deg); }
+
+  @media (prefers-contrast: more) {
+    &.-index-1 { 
+      h4,
+      p.-description {
+        color: black;
+      }
+    }
+  }
 }
 
 </style>

--- a/app/components/milestone-item.vue
+++ b/app/components/milestone-item.vue
@@ -109,6 +109,17 @@ const classObject = computed(() => {
     &:nth-child(6n+5) { transform: translateX(-120px); }
     &:nth-child(6n+6) { transform: translateX(-40px); }
   }
+
+  @media (prefers-contrast: more) {
+    border-color: black;
+    background-color: white;
+
+    .copy {
+      p {
+        color: black;
+      }
+    }
+  }
 }
 
 </style>

--- a/app/components/milestone-year.vue
+++ b/app/components/milestone-year.vue
@@ -128,6 +128,10 @@ const listStyle = computed(() => {
     font-size: 400px;
     line-height: 1;
   }
+
+  @media (prefers-contrast: more) {
+    color: black;
+  }
 }
 
 </style>

--- a/app/components/projects-item.vue
+++ b/app/components/projects-item.vue
@@ -173,6 +173,26 @@ function selectTag(tag) {
     min-height: 240px;
     flex-basis: 20%;
   }
+
+  @media (prefers-contrast: more) {
+    .tags {
+      a, button {
+        border: 1px solid black;
+        box-sizing: border-box;
+        background-color: white;
+        color: black;
+
+        &:hover {
+          background-color: #999;
+        }
+
+        &.-active {
+          background-color: black;
+          color: white;
+        }
+      }
+    }
+  }
 }
 
 </style>

--- a/app/components/section-skipper.vue
+++ b/app/components/section-skipper.vue
@@ -99,6 +99,14 @@ const isLast = computed(() => {
   @include mixins.media-query(large) {
     
   } 
+
+  @media (prefers-contrast: more) {
+    background-color: black;
+
+    button {
+      color: white;
+    }
+  }
 }
 
 </style>

--- a/app/data/testimonials.js
+++ b/app/data/testimonials.js
@@ -9,8 +9,8 @@ export default {
       description: "In 2020, a fire was lit. Few were talking about design and user experience in bitcoin, yet a transformative technology demanded a compelling narrative for interaction—one that invites everyone, not just gatekept for us nerds. The Bitcoin Design Community was born to make that vision real, a world where Freedom Tech is accessible to all.<br/><br/>Great design is more than aesthetics; it’s taste, storytelling, and experience woven into every interaction. We’ve seen other cryptographic systems falter when complexity overshadows clarity, when the story fails to inspire. Bitcoin’s promise—decentralized, borderless, empowering—deserves better. It demands interfaces that feel intuitive, narratives that resonate, and experiences that welcome.<br/><br/>Five years in and, we’ve crafted tools like the Bitcoin Design Guide and UI Kit, shaping payments and privacy into experiences anyone can navigate. We’ve rallied designers and developers to reimagine what bitcoin can be, to come together and build new tools like Alby. The work on UX Research Kit, appearances at technical events like Bitcoin Honey Badger, Advancing Bitcoin which is typically developer focus proves that good design can bridge gaps, making financial freedom tangible for communities often left behind.<br/><br/>Designers, rise up. Our creativity, our taste, our stories—they are the bridge to bitcoin’s future. Let’s craft experiences that don’t just function but inspire, that don’t just work but welcome. The next five years belong to us—to design bitcoin for everyone."
     },
     {
-      name: "Testimonial 3",
-      description: "The collaborative approach to design feedback has made our wallet more accessible to users worldwide. The community's expertise in global Bitcoin adoption is invaluable."
+      name: "Adam Jonas, Chaincode",
+      description: "Bitcoin's technological brilliance is undeniable, but its complexity has kept it within technical circles. Thank you to the design community for their crucial role in bringing this innovation to broader audiences."
     },
     {
       name: "Testimonial 4",


### PR DESCRIPTION
If the user has enabled low-contrast mode on their OS, and their browser passes that setting to the website (I think they all do), then some colors are adjusted (via [prefers-contrast](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast)). To visualize that:

Regular website view:

<img width="1728" height="992" alt="image" src="https://github.com/user-attachments/assets/703c35b0-6292-4674-9540-615b650b0974" />

With the reduced contrast vision deficiency emulation active in Chrome (Inspect -> Rendering -> Emulate vision deficiencies) - this is what the site might look like to someone who can't see very well.

<img width="1728" height="991" alt="image" src="https://github.com/user-attachments/assets/f6708ac8-142b-4d9d-8465-1946ca7a0949" />

And now we enable low-contrast mode in the MacOS system settings. The yellow on white headers are black, and various other details are adjusted to reduce opacity, etc.

<img width="1728" height="990" alt="image" src="https://github.com/user-attachments/assets/62708142-cac8-47e7-974c-e76054b10798" />

This PR fixes the most obvious contrast issues. Some tweaks to specific parts (like the green sticker at the top of the screenshot) could be made later.

---

If you want to test it, go to the [preview here](https://deploy-preview-2--bitcoin-design-5.netlify.app/) and enable "Increase contrast" in your operating systems accessibility settings.